### PR TITLE
OneCard Support & ICICI card  Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transaction-sms-parser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A library to parse transaction sms text",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,6 +13,7 @@ export const availableBalanceKeywords = [
   'total balance',
   'new balance',
   'bal',
+  'avl lmt',
 ];
 
 export const outstandingBalanceKeywords = ['outstanding'];

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -42,8 +42,8 @@ export const getTransactionAmount = (message: TMessageType): string => {
 export const getTransactionType = (message: TMessageType) => {
   const creditPattern = /(?:credited|credit|deposited|added|received|refund)/gi;
   const debitPattern = /(?:debited|debit|deducted)/gi;
-  const miscPattern =
-    /(?:payment|spent|paid|used\sat|charged|transaction\son|transaction\sfee|tran)/gi;
+  const miscPattern = /(?:payment|spent|paid|used\sat|charged|transaction\son|transaction\sfee|tran|booked|purchased)/gi;
+
 
   const messageStr = typeof message !== 'string' ? message.join(' ') : message;
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This inclused chnages in string needed to identify the avaibale amount & transaction type from onecard

- **What is the current behavior?** (You can also link to an open issue here)
Currently transaction type will not come for one card.
Available balance is not detected in ICICI Bank CreditCard

- **What is the new behavior (if this is a feature change)?**
Currently transaction type will  come for one card.
Available balance will be detected in ICICI Bank CreditCard


